### PR TITLE
fix: download contract document

### DIFF
--- a/src/features/contract-documents/contract-document.controller.ts
+++ b/src/features/contract-documents/contract-document.controller.ts
@@ -95,10 +95,12 @@ const downloadContractDocument: RequestHandler = async (req, res, next) => {
       return next(new NotFoundError('파일을 찾을 수 없습니다'));
     }
 
-    return res
-      .status(200)
-      .json({ message: '계약서 다운로드 성공' })
-      .download(document.fileUrl, document.fileName);
+    return (
+      res
+        .status(200)
+        // .json({ message: '계약서 다운로드 성공' })
+        .download(document.fileUrl, document.fileName)
+    );
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
API 명세서의 '계약서 - 계약서 다운로드 API'(`/contractDocuments/{contractDocumentId}/download`)에서는 JSON 데이터와 다운로드가 둘 다 가능하게끔 작성되어 있지만, Express.js에서 res.json() 함수와 res.download() 함수는 둘 다 클라이언트에게 응답하고 연결을 끊습니다.

실제로도 프론트엔드 예시 링크에서 계약서 파일 다운로드 시, 다운로드된 파일의 내용물이 사진 데이터가 아니라 JSON 데이터가 저장되는 버그를 확인했습니다.

원래 목적에 맞게 파일 다운로드만 가능하게 하여 문제를 해결했습니다.