### PR TITLE
feat: 계약서 업로드 로직 변경

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,5 @@ CLOUDINARY_API_SECRET=your-api-secret
 FRONTEND_URL=https://nb04-dearcarmate-team4-frontend.vercel.app
 CORS_ORIGINS=https://nb04-dearcarmate-team4-frontend.vercel.app,http://localhost:3000
 
-EMAIL_HOST=""
-EMAIL_PORT=""
-EMAIL_SECURE=false
-EMAIL_USER=""
-EMAIL_PASS=""
-EMAIL_FROM=""
+SENDER_EMAIL=
+SENDGRID_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.17.1",
+        "@sendgrid/mail": "^8.1.6",
+        "@types/morgan": "^1.9.10",
         "argon2": "^0.44.0",
         "cloudinary": "^2.7.0",
         "cors": "^2.8.5",
@@ -18,6 +20,7 @@
         "express": "^5.1.0",
         "google-auth-library": "^10.4.1",
         "jsonwebtoken": "^9.0.2",
+        "morgan": "^1.10.1",
         "multer": "^2.0.2",
         "nodemailer": "^7.0.9",
         "pg": "^8.16.3",
@@ -2234,6 +2237,44 @@
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
@@ -2996,6 +3037,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/morgan": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -3017,7 +3067,6 @@
       "version": "24.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.0.tgz",
       "integrity": "sha512-F1CBxgqwOMc4GKJ7eY22hWhBVQuMYTtqI8L0FcszYcpYX0fzfDGpez22Xau8Mgm7O9fI+zA/TYIdq3tGWfweBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.13.0"
@@ -3748,8 +3797,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.0.tgz",
+      "integrity": "sha512-zt40Pz4zcRXra9CVV31KeyofwiNvAbJ5B6YPz9pMJ+yOSLikvPT4Yi5LjfgjRa9CawVYBaD1JQzIVcIvBejKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3775,6 +3834,24 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/bignumber.js": {
@@ -4125,7 +4202,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -4337,6 +4413,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
@@ -4358,7 +4443,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4545,7 +4629,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5211,6 +5294,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -5232,7 +5335,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -5249,7 +5351,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5259,7 +5360,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -5694,7 +5794,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6514,6 +6613,49 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/morgan": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -6815,6 +6957,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -7329,6 +7480,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8659,7 +8816,6 @@
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
       "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   "type": "commonjs",
   "dependencies": {
     "@prisma/client": "^6.17.1",
+    "@sendgrid/mail": "^8.1.6",
+    "@types/morgan": "^1.9.10",
     "argon2": "^0.44.0",
     "cloudinary": "^2.7.0",
     "cors": "^2.8.5",
@@ -41,6 +43,7 @@
     "express": "^5.1.0",
     "google-auth-library": "^10.4.1",
     "jsonwebtoken": "^9.0.2",
+    "morgan": "^1.10.1",
     "multer": "^2.0.2",
     "nodemailer": "^7.0.9",
     "pg": "^8.16.3",

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import contractRoutes from '@/features/contracts/contract.routes.js';
 import dashboardRoutes from '@/features/dashboard/dashboard.routes.js';
 import { specs } from '@/documentation/swagger.config.js';
 import customerRoutes from '@/features/customers/customer.routes.js';
+import morgan from 'morgan';
 const app: Application = express();
 
 const allowedOrigins = process.env.CORS_ORIGINS
@@ -53,6 +54,7 @@ app.use(cors(corsOptions));
 app.use(express.json());
 app.use('/uploads', express.static('storage/uploads'));
 app.use(express.urlencoded({ extended: true }));
+app.use(morgan('dev'));
 
 // Swagger UI
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs));

--- a/src/features/contract-documents/contract-document.service.ts
+++ b/src/features/contract-documents/contract-document.service.ts
@@ -6,6 +6,7 @@ import {
   type ContractDocumentResponseDto,
 } from './contract-document.dto';
 import { BadRequestError } from '@/shared/middlewares/custom-error';
+import imagesService from '../images/images.service.js';
 
 export const getContractDocuments = async (
   requestDto: GetContractDocumentsRequestDto,
@@ -50,9 +51,10 @@ export const getContractDrafts = async ({
 export const uploadContractDocument = async (
   file: Express.Multer.File,
 ): Promise<UploadContractDocumentResponseDto> => {
+  const { imageUrl } = await imagesService.postImage({ path: file.path });
   const uploadedDocument =
     await contractDocumentRepository.uploadContractDocument({
-      fileUrl: file.path,
+      fileUrl: imageUrl,
       fileName: file.originalname,
       fileSize: file.size,
     });

--- a/src/shared/middlewares/email.ts
+++ b/src/shared/middlewares/email.ts
@@ -1,39 +1,59 @@
-import nodemailer from 'nodemailer';
+import sgMail from '@sendgrid/mail';
+import { InternalServerError } from './custom-error.js';
+import axios from 'axios';
 
-interface EmailAttachment {
+sgMail.setApiKey(process.env.SENDGRID_API_KEY!);
+
+interface AttachmentData {
   filename: string;
   path: string;
 }
-
-const transporter = nodemailer.createTransport({
-  host: process.env.EMAIL_HOST,
-  port: Number(process.env.EMAIL_PORT),
-  secure: process.env.EMAIL_SECURE === 'true',
-  auth: {
-    user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASS,
-  },
-});
+interface EmailAttachment {
+  content: string;
+  filename: string;
+  type: string;
+  disposition: string;
+}
 
 export const sendEmailWithAttachment = async (
   to: string,
   subject: string,
   text: string,
-  attachments: EmailAttachment[],
+  attachmentsData: AttachmentData[],
 ) => {
   try {
-    const mailOptions: nodemailer.SendMailOptions = {
-      from: process.env.EMAIL_FROM,
+    if (!process.env.SENDER_EMAIL) {
+      throw new InternalServerError('서버 에러');
+    }
+    const attachments: EmailAttachment[] = await Promise.all(
+      attachmentsData.map(async (attachmentInfo) => {
+        const response = await axios.get(attachmentInfo.path, {
+          responseType: 'arraybuffer', // Buffer 형태로 받기
+        });
+        const fileBuffer = Buffer.from(response.data);
+        const base64Content = fileBuffer.toString('base64');
+
+        return {
+          content: base64Content,
+          filename: attachmentInfo.filename,
+          type: 'application/image',
+          disposition: 'attachment',
+        };
+      }),
+    );
+
+    const mailOptions = {
+      from: process.env.SENDER_EMAIL,
       to,
       subject,
       text,
       attachments,
     };
 
-    await transporter.sendMail(mailOptions);
+    await sgMail.send(mailOptions);
     console.log(`Email sent to ${to}`);
   } catch (error) {
     console.error('Error sending email:', error);
-    throw new Error('Email could not be sent');
+    throw new InternalServerError('Email could not be sent');
   }
 };


### PR DESCRIPTION
#69 관련 PR입니다.

프론트에서 보내는 요청을 로깅해주는 morgan 추가했습니다.

배포환경을 고려해 계약서 자체도 로컬 스토리지 대신 클라우디너리로 저장하는 방식으로 변경했습니다.
계약서도 jpg/png만 허용하길래 클라우디너리 사용했습니다.

이메일 전송 방식도 sendgrid 외부 api를 사용하는 방식으로 변경했습니다.

로컬 테스트 결과 잘 동작했습니다.

.env.example 참고해 환경변수 변경해야합니다.